### PR TITLE
Fixing ColorForHex function. 

### DIFF
--- a/lib/webcolor.js
+++ b/lib/webcolor.js
@@ -72,7 +72,7 @@ function colorForHex(hexCode) {
     var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hexCode);
 
     if (result) {
-        return RGBACOLOR(parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16), 1);
+        return RGBACOLOR(parseInt(result[1], 16) / 255, parseInt(result[2], 16) / 255, parseInt(result[3], 16) / 255, 1);
     }
 
     Ti.API.warn("Hex color passed looks invalid: " + hexCode);


### PR DESCRIPTION
Previously ColorForHex was calling RGBACOLOR with values between 0-255. I've changed it to send from 0-1, which is what **colorWithRedGreenBlueAlpha** accepts
